### PR TITLE
Add Custom Network Interface at mech up

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Options:
   --no-cache                    Do not save the downloaded box.
   --no-nat                      Do not use NAT networking (i.e., use bridged).
   --numvcpus VCPUS              Specify number of vcpus.
-  --add-custom-interface VMNET  Add a custom netowrk interface (i.e., VMnet3)
+  --add-custom-interface VMNET  Add a custom netowrk interface (i.e., 3 for VMnet3)
   -r, --remove-vagrant          Remove vagrant user.
   -h, --help                    Show this message and exit.
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Usage: mech up [OPTIONS] [INSTANCE]
 
   If no instance is specified, all instances will be started.
 
-  The options ('memsize', 'numvcpus', and 'no-nat') will only be applied
+  The options ('memsize', 'numvcpus', add-custom-interface, and 'no-nat') will only be applied
   upon first run of the 'up' command.
 
   The 'no-nat' option will only be applied if there is no network interface
@@ -110,15 +110,16 @@ Usage: mech up [OPTIONS] [INSTANCE]
   root cannot ssh, or change the root password.
 
 Options:
-  --disable-provisioning    Do not provision.
-  --disable-shared-folders  Do not share folders.
-  --gui                     Start GUI, otherwise starts headless.
-  --memsize MEMORY          Specify memory size in MB.
-  --no-cache                Do not save the downloaded box.
-  --no-nat                  Do not use NAT networking (i.e., use bridged).
-  --numvcpus VCPUS          Specify number of vcpus.
-  -r, --remove-vagrant      Remove vagrant user.
-  -h, --help                Show this message and exit.
+  --disable-provisioning        Do not provision.
+  --disable-shared-folders      Do not share folders.
+  --gui                         Start GUI, otherwise starts headless.
+  --memsize MEMORY              Specify memory size in MB.
+  --no-cache                    Do not save the downloaded box.
+  --no-nat                      Do not use NAT networking (i.e., use bridged).
+  --numvcpus VCPUS              Specify number of vcpus.
+  --add-custom-interface VMNET  Add a custom netowrk interface (i.e., VMnet3)
+  -r, --remove-vagrant          Remove vagrant user.
+  -h, --help                    Show this message and exit.
 ```
 
 # Example using mech

--- a/mech/mech.py
+++ b/mech/mech.py
@@ -734,7 +734,7 @@ def global_status(ctx, purge):
 @click.option('--no-nat', is_flag=True, default=False,
               help='Do not use NAT networking (i.e., use bridged).')
 @click.option('--numvcpus', metavar='VCPUS', help='Specify number of vcpus.')
-@click.option('--add-custom-interface', metavar='VMNET', help='Add a custom network interface (e.g. VMnet3)')
+@click.option('--add-custom-interface', metavar='VMNET', help='Add a custom netowrk interface (i.e., 3 for VMnet3)')
 @click.option('-r', '--remove-vagrant', is_flag=True, default=False, help='Remove vagrant user.')
 @click.pass_context
 def up(ctx, instance, disable_provisioning, disable_shared_folders, gui, memsize, no_cache,

--- a/mech/mech.py
+++ b/mech/mech.py
@@ -734,10 +734,11 @@ def global_status(ctx, purge):
 @click.option('--no-nat', is_flag=True, default=False,
               help='Do not use NAT networking (i.e., use bridged).')
 @click.option('--numvcpus', metavar='VCPUS', help='Specify number of vcpus.')
+@click.option('--add-custom-interface', metavar='VMNET', help='Add a custom network interface (e.g. VMnet3)')
 @click.option('-r', '--remove-vagrant', is_flag=True, default=False, help='Remove vagrant user.')
 @click.pass_context
 def up(ctx, instance, disable_provisioning, disable_shared_folders, gui, memsize, no_cache,
-       no_nat, numvcpus, remove_vagrant):
+       no_nat, numvcpus, add_custom_interface, remove_vagrant):
     '''
     Starts and provisions instance(s).
 
@@ -745,7 +746,7 @@ def up(ctx, instance, disable_provisioning, disable_shared_folders, gui, memsize
 
     If no instance is specified, all instances will be started.
 
-    The options ('memsize', 'numvcpus', and 'no-nat') will only be applied
+    The options ('memsize', 'numvcpus', 'add-custom-interface', and 'no-nat') will only be applied
     upon first run of the 'up' command.
 
     The 'no-nat' option will only be applied if there is no network
@@ -768,7 +769,7 @@ def up(ctx, instance, disable_provisioning, disable_shared_folders, gui, memsize
     LOGGER.debug('cloud_name:%s instance:%s disable_provisioning:%s disable_shared_folders:%s '
                  'gui:%s memsize:%s no_cache:%s no_nat:%s numvcpus:%s remove_vagrant:%s',
                  cloud_name, instance, disable_provisioning, disable_shared_folders,
-                 gui, memsize, no_cache, no_nat, numvcpus, remove_vagrant)
+                 gui, memsize, no_cache, no_nat, numvcpus, add_custom_interface, remove_vagrant)
 
     if cloud_name:
         utils.cloud_run(cloud_name, ['up', 'start'])
@@ -808,6 +809,7 @@ def up(ctx, instance, disable_provisioning, disable_shared_folders, gui, memsize
                 instance_path=inst.path,
                 save=not no_cache,
                 numvcpus=numvcpus,
+                add_custom_interface = add_custom_interface,
                 memsize=memsize,
                 no_nat=no_nat,
                 windows=inst.windows,

--- a/mech/utils.py
+++ b/mech/utils.py
@@ -452,7 +452,7 @@ def tar_cmd(*args, **kwargs):
 
 
 def init_box(name, box=None, box_version=None, location=None, force=False, save=True,
-             instance_path=None, numvcpus=None, add_custom_interface=False, memsize=None, no_nat=False, provider=None,
+             instance_path=None, numvcpus=None, add_custom_interface=None, memsize=None, no_nat=False, provider=None,
              windows=None):
     """Initialize the box. This includes uncompressing the files
        from the box file and updating the vmx file with

--- a/mech/utils.py
+++ b/mech/utils.py
@@ -240,7 +240,7 @@ def parse_vmx(path):
     return vmx
 
 
-def update_vmx(path, numvcpus=None, memsize=None, no_nat=False):
+def update_vmx(path, numvcpus=None, memsize=None, no_nat=False, add_custom_interface=None):
     """Update the virtual machine configuration (.vmx)
        file with desired settings.
     """
@@ -276,6 +276,16 @@ def update_vmx(path, numvcpus=None, memsize=None, no_nat=False):
 
     if memsize is not None:
         vmx["memsize"] = '"{}"'.format(memsize)
+        updated = True
+
+    if add_custom_interface is not None:
+        vmx["ethernet1.connectionType"] = "custom"
+        vmx["ethernet1.addressType"] = "generated"
+        vmx["ethernet1.vnet"] = "VMnet" + '{}'.format(add_custom_interface)
+        vmx["ethernet1.displayname"] = "VMnet" + '{}'.format(add_custom_interface)
+        vmx["ethernet1.virtualDev"] = "e1000e"
+        vmx["ethernet1.present"] = "TRUE"
+        click.secho("Added custom network interface to vmx file", fg="yellow")
         updated = True
 
     if updated:
@@ -442,7 +452,7 @@ def tar_cmd(*args, **kwargs):
 
 
 def init_box(name, box=None, box_version=None, location=None, force=False, save=True,
-             instance_path=None, numvcpus=None, memsize=None, no_nat=False, provider=None,
+             instance_path=None, numvcpus=None, add_custom_interface=False, memsize=None, no_nat=False, provider=None,
              windows=None):
     """Initialize the box. This includes uncompressing the files
        from the box file and updating the vmx file with
@@ -515,7 +525,7 @@ def init_box(name, box=None, box_version=None, location=None, force=False, save=
         vmx_path = locate(instance_path, '*.vmx')
         if not vmx_path:
             sys.exit(click.style("Cannot locate a VMX file", fg="red"))
-        update_vmx(vmx_path, numvcpus=numvcpus, memsize=memsize, no_nat=no_nat)
+        update_vmx(vmx_path, numvcpus=numvcpus, memsize=memsize, no_nat=no_nat, add_custom_interface=add_custom_interface)
         return vmx_path
     else:
         ovf_path = locate(instance_path, '*.ovf')


### PR DESCRIPTION
When first creating a VM with `mech up`, it'd be nice to add a custom network interface for VMware. Using the following command, users can add a custom interface for testing various networks. 

`mech up --add-custom-network 3` 

The above command would add VMnet3 to the .vmx file. 